### PR TITLE
Update test seq web address

### DIFF
--- a/ccontigs.jl
+++ b/ccontigs.jl
@@ -40,11 +40,13 @@ hitlength = parsed_args["length"]
 threshold = hitlength * 5 * parsed_args["thresh"]
 maxscore = hitlength * 5
 print("Perfect alignment score is $maxscore\n")
+inputfasta = FASTA.Reader(open( filepath))
 
-for s in open( filepath, FASTA )
-    alignment_result = pairalign(problem, s.seq[1:hitlength], s.seq[hitlength:end], scoremodel)
+
+for s in inputfasta
+    alignment_result = pairalign(problem, FASTA.sequence(s , 1:hitlength), FASTA.sequence(s , hitlength:length(FASTA.sequence(s))), scoremodel)
     scorestring = score(alignment_result)
-    seqname = s.name
+    seqname = FASTA.identifier(s)
     if scorestring > threshold
         write(outputfile, "$seqname\t$scorestring\n")
     end

--- a/test/downloadtestseqs.sh
+++ b/test/downloadtestseqs.sh
@@ -10,7 +10,7 @@ AccString=$(cut -f 2 ${AccessionList} | tr '\n' ',' | sed 's/,$//')
 
 # Download the test dataset
 echo Downloading Sequences
-wget "http://www.ebi.ac.uk/ena/data/view/${AccString}&display=fasta" -O ./tmpout
+wget "https://www.ebi.ac.uk/ena/data/view/${AccString}&display=fasta" -O ./tmpout
 
 perl ./remove_block_fasta_format.pl \
 	./tmpout \


### PR DESCRIPTION
The EMBL-EBI address redirects from the old http site to the new secure https site. This doesn't create an error but the output looks different from the readme. Tested the change and it fixes it